### PR TITLE
Refactor Domain tests for Category to use TestCase instead of Test

### DIFF
--- a/tests/Eshop.Domain.Tests/CategoryTests.cs
+++ b/tests/Eshop.Domain.Tests/CategoryTests.cs
@@ -1,3 +1,5 @@
+using Eshop.Domain.Tests.Utils;
+
 namespace Eshop.Domain.Tests
 {
     public class CategoryTests
@@ -6,8 +8,8 @@ namespace Eshop.Domain.Tests
         public void Category_WithValidParams_SetCorrectlyProperties()
         {
             // arrange
-            var id = 1;
-            var name = GenerateRandomString(50);
+            var id = 0; // Zero is valid for a new object (EF)
+            var name = StringUtils.GenerateRandomString(50);
 
             // act
             var sut = new Category(id, name);
@@ -20,51 +22,24 @@ namespace Eshop.Domain.Tests
         [Test]
         public void Category_WithInvalidIdParam_ThrowsException()
         {
-            // arrange
-            var id = -1;
-
             // act/assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Category(id, null!));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Category(-1, "Category Name"));
         }
 
-        [Test]
-        public void Category_WithNullNameParam_ThrowsException()
+        [TestCase(null)]
+        [TestCase(" ")]
+        [TestCase("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxy")] // 51 chars
+        public void Category_WithInvalidParams_ThrowsException(string? name)
         {
-            // arrange
-            var id = 0;
-            string name = null!;
-
             // act/assert
-            Assert.Throws<ArgumentNullException>(() => new Category(id, name));
-        }
-
-        [Test]
-        public void Category_WithEmptyNameParam_ThrowsException()
-        {
-            // arrange
-            var id = 0;
-            var name = " ";
-
-            // act/assert
-            Assert.Throws<ArgumentNullException>(() => new Category(id, name));
-        }
-
-        [Test]
-        public void Category_WithLongNameParam_ThrowsException()
-        {
-            // arrange
-            var id = 0;
-            var name = GenerateRandomString(51);
-
-            // act/assert
-            Assert.Throws<ArgumentNullException>(() => new Category(id, name));
+            Assert.Throws<ArgumentNullException>(() => new Category(0, name!));
         }
 
         [Test]
         public void CategoryUpdate_WithValidParams_SetsPropertiesCorreclty()
         {
             // arrange
-            var newCategoryName = GenerateRandomString(50);
+            var newCategoryName = StringUtils.GenerateRandomString(50);
             var category = new Category(0, "Notebook");
 
             // act
@@ -74,51 +49,16 @@ namespace Eshop.Domain.Tests
             Assert.That(category.Name, Is.EqualTo(newCategoryName));
         }
 
-        [Test]
-        public void CategoryUpdate_WithNullNameParam_ThrowsException()
+        [TestCase(null)]
+        [TestCase(" ")]
+        [TestCase("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxy")] // 51 chars
+        public void CategoryUpdate_WithInvalidParams_ThrowsException(string? newCategoryName)
         {
             // arrange
-            string newCategoryName = null!;
             var category = new Category(0, "Notebook");
 
             // act/assert
-            Assert.Throws<ArgumentNullException>(() => category.Udpate(newCategoryName));
-        }
-
-        [Test]
-        public void CategoryUpdate_WithEmptyNameParam_ThrowsException()
-        {
-            // arrange
-            var newCategoryName = " ";
-            var category = new Category(0, "Notebook");
-
-            // act/assert
-            Assert.Throws<ArgumentNullException>(() => category.Udpate(newCategoryName));
-        }
-
-        [Test]
-        public void CategoryUpdate_WithLongNameParam_ThrowsException()
-        {
-            // arrange
-            var newCategoryName = GenerateRandomString(51);
-            var category = new Category(0, "Notebook");
-
-            // act/assert
-            Assert.Throws<ArgumentNullException>(() => category.Udpate(newCategoryName));
-        }
-
-        static string GenerateRandomString(int length)
-        {
-            Random random = new();
-            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";  // Can be expanded if needed
-            char[] stringChars = new char[length];
-
-            for (int i = 0; i < length; i++)
-            {
-                stringChars[i] = chars[random.Next(chars.Length)];
-            }
-
-            return new string(stringChars);
+            Assert.Throws<ArgumentNullException>(() => category.Udpate(newCategoryName!));
         }
     }
 }

--- a/tests/Eshop.Domain.Tests/Utils/StringUtils.cs
+++ b/tests/Eshop.Domain.Tests/Utils/StringUtils.cs
@@ -1,0 +1,19 @@
+﻿namespace Eshop.Domain.Tests.Utils
+{
+    public static class StringUtils
+    {
+        public static string GenerateRandomString(int length)
+        {
+            Random random = new();
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";  // Can be expanded if needed
+            char[] stringChars = new char[length];
+
+            for (int i = 0; i < length; i++)
+            {
+                stringChars[i] = chars[random.Next(chars.Length)];
+            }
+
+            return new string(stringChars);
+        }
+    }
+}


### PR DESCRIPTION
We want to simplify our domain tests.
Where ever we do have repeatable action e.g. for ArgumentNullException we can use TestCase instead of Test.
This gives us just 1 method with 3 variations instead of 3 methods for each case.
Basically the validation is used in ctor same as for update which means that we save a lot of code by using TestCase so we will have just 2 tests instead of 6.